### PR TITLE
Uncommented startCamera() in smAcquireImage() to send software trigge…

### DIFF
--- a/pcowinApp/src/Pco.cpp
+++ b/pcowinApp/src/Pco.cpp
@@ -706,7 +706,7 @@ StateMachine::StateSelector Pco::smAcquireImage()
 	StateMachine::StateSelector result;
     if(!receiveImages())
     {
-        //startCamera();
+        startCamera();
         result = StateMachine::firstState;
     }
     else


### PR DESCRIPTION
…rs when in armed mode

It appears that this line was unintentionally left commented out, which prevents more software triggers being sent after the first (see smUnarmedAcquireImage() for comparison).

I have tested this change and I am able to use both internal and external triggering, so this fixes #8.