### PR TITLE
Fix missing PVs in save restore

### DIFF
--- a/iocs/pcowinIOC/iocBoot/iocPcoWin/auto_settings.req
+++ b/iocs/pcowinIOC/iocBoot/iocPcoWin/auto_settings.req
@@ -1,2 +1,3 @@
-file "NDStdArrays_settings.req",          P=$(P),  R=image1:
-file "commonPlugin_settings.req",         P=$(P)
+file "pco_settings.req", 		P=$(P), R=cam1:
+file "NDStdArrays_settings.req",	P=$(P),	R=image1:
+file "commonPlugin_settings.req",	P=$(P)

--- a/pcowinApp/Db/pco_settings.req
+++ b/pcowinApp/Db/pco_settings.req
@@ -1,0 +1,1 @@
+file "ADBase_settings.req", P=$(P), R=$(R)

--- a/pcowinApp/src/Pco.cpp
+++ b/pcowinApp/src/Pco.cpp
@@ -706,7 +706,7 @@ StateMachine::StateSelector Pco::smAcquireImage()
 	StateMachine::StateSelector result;
     if(!receiveImages())
     {
-        //startCamera();
+        startCamera();
         result = StateMachine::firstState;
     }
     else


### PR DESCRIPTION
Added ADBase_settings.req to the list of the save/restore files the same way as other areaDetector Modules do. Now save restore is working for the missing PVs. This fixes #10 . Diamond team is welcome to add more PCO specific PVs to pco_settings.req. My customers did not ask for anything else so far. 