### PR TITLE
Fixes to allow building dynamically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,25 +3,30 @@ TOP = .
 include $(TOP)/configure/CONFIG
 DIRS := $(DIRS) $(filter-out $(DIRS), configure)
 DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard *App))
-DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocBoot))
+
+ifeq ($(BUILD_IOCS), YES)
+DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocs))
+iocs_DEPEND_DIRS += pcowinApp
+endif
 
 define DIR_template
  $(1)_DEPEND_DIRS = configure
 endef
 $(foreach dir, $(filter-out configure,$(DIRS)),$(eval $(call DIR_template,$(dir))))
 
-iocBoot_DEPEND_DIRS += $(filter %App,$(DIRS))
-
-# Comment out the following lines to disable creation of example iocs and documentation
-#DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard etc))
-
 ifeq ($(wildcard etc),etc)
 	UNINSTALL_DIRS += documentation/doxygen $(IOC_DIRS)
 endif
 
-# Comment out the following line to disable building of example iocs
-DIRS := $(DIRS) $(filter-out $(DIRS), $(wildcard iocs))
-
 include $(TOP)/configure/RULES_TOP
 
+uninstall: uninstall_iocs
+uninstall_iocs:
+	$(MAKE) -C iocs uninstall
+.PHONY: uninstall uninstall_iocs
+
+realuninstall: realuninstall_iocs
+realuninstall_iocs:
+	$(MAKE) -C iocs realuninstall
+.PHONY: realuninstall realuninstall_iocs
 

--- a/pcowinApp/src/Makefile
+++ b/pcowinApp/src/Makefile
@@ -2,7 +2,7 @@ TOP=../..
 
 include $(TOP)/configure/CONFIG
 
-LIBRARY_IOC += pcowin
+LIBRARY_IOC_WIN32 += pcowin
 
 # xxxRecord.h will be created from xxxRecord.dbd
 #DBDINC += xxx.h
@@ -44,34 +44,39 @@ USR_INCLUDES_WIN32 += -I../include/
 
 # These are the vendor libraries
 ifeq (win32-x86, $(findstring win32-x86, $(T_A)))
-LIB_INSTALLS += $(wildcard ../lib/*.lib)
-BIN_INSTALLS += $(wildcard ../dll/*.dll)
-USR_CFLAGS += -DDEBUG  /Zi /O2
-USR_CPPFLAGS += -DDEBUG /Zi /O2
-USR_LDFLAGS += /INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF
+  LIB_INSTALLS += $(wildcard ../lib/*.lib)
+  BIN_INSTALLS += $(wildcard ../dll/*.dll)
+  USR_CFLAGS += -DDEBUG  /Zi /O2
+  USR_CPPFLAGS += -DDEBUG /Zi /O2
+  USR_LDFLAGS += /INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF
 else ifeq (windows-x64-debug, $(findstring windows-x64-debug, $(T_A)))
-LIB_INSTALLS += $(wildcard ../lib64/*.lib)
-BIN_INSTALLS += $(wildcard ../dll64/*.dll)
-USR_CFLAGS += /wd4290
-USR_CPPFLAGS += /wd4290
-#USR_LDFLAGS += /INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF
+  LIB_INSTALLS += $(wildcard ../lib64/*.lib)
+  BIN_INSTALLS += $(wildcard ../dll64/*.dll)
+  USR_CFLAGS += /wd4290
+  USR_CPPFLAGS += /wd4290
+  #USR_LDFLAGS += /INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF
 else ifeq (windows-x64, $(findstring windows-x64, $(T_A)))
-LIB_INSTALLS += $(wildcard ../lib64/*.lib)
-BIN_INSTALLS += $(wildcard ../dll64/*.dll)
-USR_CFLAGS += /O2 /wd4290
-USR_CPPFLAGS += /O2 /wd4290
-USR_LDFLAGS += /INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF
+  LIB_INSTALLS += $(wildcard ../lib64/*.lib)
+  BIN_INSTALLS += $(wildcard ../dll64/*.dll)
+  USR_CFLAGS += /O2 /wd4290
+  USR_CPPFLAGS += /O2 /wd4290
+  USR_LDFLAGS += /INCREMENTAL:NO /DEBUG /OPT:REF /OPT:ICF
 else
-USR_CPPFLAGS += -DDEBUG -O0
-USR_CFLAGS += -DDEBUG  -O0
+  USR_CPPFLAGS += -DDEBUG -O0
+  USR_CFLAGS += -DDEBUG  -O0
+endif
+
+ifeq ($(SHARED_LIBRARIES), YES)
+  USR_CPPFLAGS += -D_AFXDLL
 endif
 
 #switch off optimization for debugging
 #HOST_OPT=NO
 
-# We need to link against the EPICS Base libraries
-pcowin_LIBS += $(EPICS_BASE_IOC_LIBS)
-
-
+include $(ADCORE)/ADApp/commonLibraryMakefile
+LIB_LIBS += PCO_CDlg Pco_conv SC2_Cam SC2_DLG
 
 include $(TOP)/configure/RULES
+
+# This rule is needed so the vendor libraries get installed before the library is built
+$(LIBNAME) $(SHRLIBNAME): $(INSTALL_BIN_INSTALLS) $(INSTALL_LIB_INSTALLS)


### PR DESCRIPTION
The top-level Makefile was changed:
- Obey BUILD_IOCS
- Allow parallel make, by forcing pcowinApp to build before iocs
- Allows "make uninstall" to descend into iocs

The pcowinApp Makefile was changed:
- Only build on WIN32, avoids errors if Linux build is done in directory
- Install vendor libraries before building pcowin library, needed for LIB_LIBS
- Include commonLibraryMakefile, needed for dynamic builds
- Add vendor LIB_LIBS
- Add -D_AFXDLL needed to build dynamically
- Use indentation to make file more readable