### PR TITLE
Update/dls changes upstream

### DIFF
--- a/pcowinApp/src/Pco.cpp
+++ b/pcowinApp/src/Pco.cpp
@@ -3067,7 +3067,9 @@ void Pco::processFrame(NDArray* image)
             epicsTimeGetCurrent(&imageTime);
         }
         image->timeStamp = imageTime.secPastEpoch +
-                imageTime.nsec / Pco::oneNanosecond;
+                imageTime.nsec * Pco::oneNanosecond;
+        // Required as of ADCore 2-0 - https://cars.uchicago.edu/software/epics/areaDetectorTimeStampSupport.html
+        updateTimeStamp(&image->epicsTS);
         this->getAttributes(image->pAttributeList);
         // Show the image to the gang system
         if(this->gangConnection)

--- a/pcowinApp/src/Pco.cpp
+++ b/pcowinApp/src/Pco.cpp
@@ -71,6 +71,7 @@ const double Pco::oneNanosecond = 1e-9;
 const double Pco::oneMillisecond = 1e-3;
 const double Pco::triggerRetryPeriod = 0.01;
 const int Pco::statusMessageSize = 256;
+
 /** Aligned allocation for DLL buffers. */
 #ifdef _WIN32
 #else

--- a/pcowinApp/src/Pco.cpp
+++ b/pcowinApp/src/Pco.cpp
@@ -384,7 +384,7 @@ void Pco::initialiseOnceRunning()
 
 /**
  * Return the pco corresponding to the port name
- * \param[in] p The port name
+ * \param[in] portName The port name
  * \return The pco object, NULL if not found
  */
 Pco* Pco::getPco(const char* portName)
@@ -1709,7 +1709,7 @@ void Pco::post(const StateMachine::Event* req)
  */
 NDArray* Pco::allocArray(int sizeX, int sizeY, NDDataType_t dataType)
 {
-    size_t maxDims[] = {sizeX, sizeY};
+    size_t maxDims[] = {(size_t) sizeX, (size_t) sizeY};
     NDArray* image = this->pNDArrayPool->alloc(sizeof(maxDims)/sizeof(size_t),
             maxDims, dataType, 0, NULL);
     if(image == NULL)

--- a/pcowinApp/src/Pco.cpp
+++ b/pcowinApp/src/Pco.cpp
@@ -3037,6 +3037,11 @@ void Pco::processFrame(NDArray* image)
     }
     if(nextImageReady)
     {
+        // Update statistics if not a client
+        if (!this->gangConnection){
+            this->arrayCounter++;
+            this->numImagesCounter++;
+        }
         // Attach the image information
         image->uniqueId = this->arrayCounter;
         epicsTimeStamp imageTime;
@@ -3074,9 +3079,6 @@ void Pco::processFrame(NDArray* image)
  */
 void Pco::imageComplete(NDArray* image)
 {
-    // Update statistics
-    this->arrayCounter++;
-    this->numImagesCounter++;
     // Pass the array on
     this->doCallbacksGenericPointer(image, NDArrayData, 0);
     image->release();

--- a/pcowinApp/src/Pco.cpp
+++ b/pcowinApp/src/Pco.cpp
@@ -2538,8 +2538,8 @@ void Pco::cfgBinningAndRoi(bool updateParams) throw(PcoException)
         this->reqRoiPercentY = std::min(this->reqRoiPercentY, 100);
 
         // Deduce region size from percentage
-        this->reqRoiSizeX = (this->xCamSize * this->reqRoiPercentX) / 100.0;
-        this->reqRoiSizeY = (this->yCamSize * this->reqRoiPercentY) / 100.0;
+        this->reqRoiSizeX = int((this->xCamSize * this->reqRoiPercentX) / 100.0);
+        this->reqRoiSizeY = int((this->yCamSize * this->reqRoiPercentY) / 100.0);
 
         // Deduce starting coordinates by making region symmetrical
         this->reqRoiStartX = (this->xCamSize - this->reqRoiSizeX) / 2;

--- a/pcowinApp/src/Pco.h
+++ b/pcowinApp/src/Pco.h
@@ -130,6 +130,7 @@ public:
     static const double armIgnoreImagesPeriod;
     static const double acquisitionStatusPollPeriod;
     static const double initialisationPeriod;
+    static const double acquireStartEventTimeout;
     static const char* stateNames[];
     static const char* eventNames[];
     static const int bitsPerShortWord;
@@ -283,7 +284,6 @@ private:
     int fifoQueueSize;
     bool useGetFrames;
     epicsEventId acquireStartedEvent;
-    int acquireStartEventTimeout;
 
 public:
     static std::map<std::string, Pco*> thePcos;

--- a/pcowinApp/src/Pco.h
+++ b/pcowinApp/src/Pco.h
@@ -33,6 +33,10 @@ public:
     Pco(const char* portName, int maxBuffers, size_t maxMemory, int numCameraDevices);
     virtual ~Pco();
 
+// These are the methods that we override from ADDriverEx */
+public:
+  virtual asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
+
 // Parameters
 public:
     IntegerParam paramPixRate;
@@ -278,6 +282,8 @@ private:
     unsigned long memoryImageCounter;
     int fifoQueueSize;
     bool useGetFrames;
+    epicsEventId acquireStartedEvent;
+    int acquireStartEventTimeout;
 
 public:
     static std::map<std::string, Pco*> thePcos;


### PR DESCRIPTION
This can be more easily compared to master after PR #20 when indentations have been converted to spaces.

There are a few changes/fixes in this PR:
1. Timestamp calculation is corrected (nanosecond counter was being divided by 1e-9 instead of multiplied)
2. An event is now used to check that the camera acquisition is started before acquire PV is set
3. Unique ID is now 1-indexed, consistent with most other Area Detector drivers